### PR TITLE
Encode email/token before sending it with AJAX

### DIFF
--- a/src/coffee/app.coffee
+++ b/src/coffee/app.coffee
@@ -31,7 +31,10 @@ FallingFruitApp.config ['$httpProvider', ($httpProvider)->
     interceptor =
       request: (config)->
         if AuthFactory.needsAuth(config.url)
-          auth_param = "user_email=#{AuthFactory.get_email()}&auth_token=#{AuthFactory.get_access_token()}&api_key=BJBNKMWM"
+          email = encodeURIComponent(AuthFactory.get_email())
+          token = encodeURIComponent(AuthFactory.get_access_token())
+
+          auth_param = "user_email=#{email}&auth_token=#{token}&api_key=BJBNKMWM"
           config.url += if config.url.indexOf("?") == -1 then "?#{auth_param}" else "&#{auth_param}"
 
         return config || $q.when(config)


### PR DESCRIPTION
@ezwelty There's a bug where if you have a `+` char in the email address (like `dbalatero+ff@gmail.com`), it gets interpreted as a space server-side instead of a `+` due to URL encoding. This URL encodes the auth parameters before sending them up to the server.

In general, I'm concerned with how much raw query string is getting built by hand. I'd prefer to see something like this:

```js
$.ajax(url, params: { foo: 'bar', baz: '203' })
```

which would take care of encoding the params automatically, avoiding these bugs. Not sure if the http/ajax lib you're using has that feature, but should be considered!