### PR TITLE
Make maps and list use same api call

### DIFF
--- a/src/coffee/app.coffee
+++ b/src/coffee/app.coffee
@@ -118,8 +118,7 @@ urls =
   register: auth_host + "/users.json"
   forgot_password: auth_host + "/users/password.json"
 
-  nearby: api_host + "/locations.json"
-  markers: api_host + "/locations.json"
+  locations: api_host + "/locations.json"
 
   location: api_host + "/locations/"
   add_location: api_host + "/locations.json"

--- a/src/coffee/directives.coffee
+++ b/src/coffee/directives.coffee
@@ -60,8 +60,9 @@ directives.mapContainer = ()->
       clear_offscreen_markers(bounds)
       return if window.FFApp.markersArray.length >= window.FFApp.markersMax
 
-      locationsService.fetchData
-        onSuccess: (json) ->
+      locationsService
+        .fetchData()
+        .success (json) ->
           add_markers_from_json(json)
           mapStateService.removeLoading()
 

--- a/src/coffee/directives.coffee
+++ b/src/coffee/directives.coffee
@@ -6,7 +6,7 @@ directives.mapContainer = ()->
   scope:
     stoplist: "="
     directionstype: "="
-  controller: ($scope, $element, $http, $rootScope, mapStateService)->
+  controller: ($scope, $element, $http, $rootScope, mapStateService, locationsService)->
     container_elem = $element[0]
 
     # Map settings
@@ -59,22 +59,11 @@ directives.mapContainer = ()->
       bounds = window.FFApp.map_obj.getBounds()
       clear_offscreen_markers(bounds)
       return if window.FFApp.markersArray.length >= window.FFApp.markersMax
-      list_params =
-        nelat: bounds.getNorthEast().lat()
-        nelng: bounds.getNorthEast().lng()
-        swlat: bounds.getSouthWest().lat()
-        swlng: bounds.getSouthWest().lng()
-      if window.FFApp.muni
-        list_params.muni = 1
-      else
-        list_params.muni = 0
-      list_params.c = window.FFApp.cats unless window.FFApp.cats is null
-      list_params.t = window.FFApp.selectedType.id unless window.FFApp.selectedType is null
-      $http.get(urls.markers,
-        params: list_params
-      ).success (json) ->
-        add_markers_from_json(json)
-        mapStateService.removeLoading()
+
+      locationsService.fetchData
+        onSuccess: (json) ->
+          add_markers_from_json(json)
+          mapStateService.removeLoading()
 
     find_marker = (lid) ->
       i = 0

--- a/src/coffee/search.coffee
+++ b/src/coffee/search.coffee
@@ -40,10 +40,10 @@ controllers.SearchCtrl = ($scope, $rootScope, $http, $location, $timeout, AuthFa
     $scope.targeted = false
     $scope.add_location_controls = false
 
-    locationsService.fetchData
-      bounds: bounds
-      onSuccess: (locations) ->
-        console.log("in success handleR")
+    locationsService
+      .fetchData(bounds: bounds)
+      .success (locations) ->
+        console.log("in success handler")
 
         n_found = locations.shift()
         n_limit = locations.shift()
@@ -61,7 +61,6 @@ controllers.SearchCtrl = ($scope, $rootScope, $http, $location, $timeout, AuthFa
         $scope.list_items = locations
         $scope.list_bounds = bounds
 
-        debugger
         mapStateService.removeLoading()
 
   ## Side menu

--- a/src/coffee/search.coffee
+++ b/src/coffee/search.coffee
@@ -60,23 +60,24 @@ controllers.SearchCtrl = ($scope, $rootScope, $http, $location, $timeout, AuthFa
     list_params.t = window.FFApp.selectedType.id unless window.FFApp.selectedType is null
     list_params.c = window.FFApp.cats unless window.FFApp.cats is null
 
-    $http.get urls.nearby, params: list_params
-    .success (data)->
-      n_found = data.shift()
-      n_limit = data.shift()
-      for item in data
-        if item.hasOwnProperty("photos") and item.photos[0][0].thumbnail.indexOf("missing.png") == -1
-          background_url = "url('#{item.photos[0][0].thumbnail}')"
-        else
-          background_url = "url('img/png/no-image.png')"
+    $http
+      .get(urls.nearby, params: list_params)
+      .success (data)->
+        n_found = data.shift()
+        n_limit = data.shift()
+        for item in data
+          if item.hasOwnProperty("photos") and item.photos[0][0].thumbnail.indexOf("missing.png") == -1
+            background_url = "url('#{item.photos[0][0].thumbnail}')"
+          else
+            background_url = "url('img/png/no-image.png')"
 
-        item.distance_string = I18nFactory.distance_string(item.distance)
-        item.style =
-          "background-image": background_url
+          item.distance_string = I18nFactory.distance_string(item.distance)
+          item.style =
+            "background-image": background_url
 
-      $scope.list_items = data
-      mapStateService.removeLoading()
-      $scope.list_bounds = bounds
+        $scope.list_items = data
+        mapStateService.removeLoading()
+        $scope.list_bounds = bounds
 
   ## Side menu
   $scope.toggleSideMenu = ()->

--- a/src/coffee/services.coffee
+++ b/src/coffee/services.coffee
@@ -33,16 +33,10 @@ factories.edibleTypesService = ($http)->
   return props
 
 factories.locationsService = ($http) ->
-  cachedData = null
-  lastSearchParams = null
-
   props = {}
 
-  props.fetchData = (options) ->
+  props.fetchData = (options = {}) ->
     console.log("locationsService.fetchData()")
-
-    onSuccess = options.onSuccess ||
-      throw new Error("locationsService.fetchData() requires an onSuccess handler")
 
     # bounds can be optionally passed in as a key
     bounds = options.bounds || window.FFApp.map_obj.getBounds()
@@ -64,22 +58,7 @@ factories.locationsService = ($http) ->
     params.c = window.FFApp.cats unless window.FFApp.cats is null
     params.t = window.FFApp.selectedType.id unless window.FFApp.selectedType is null
 
-    console.log("cachedData = ", cachedData)
-    console.log("lastSearchParams = ", lastSearchParams)
-    console.log("params = ", params)
-
-    if cachedData && _.isEqual(lastSearchParams, params)
-      console.log("--> hit the cache")
-      return onSuccess(cachedData)
-
-    lastSearchParams = params
-
-    $http
-      .get(urls.locations, params: params)
-      .success (json) ->
-        console.log("--> loaded from http")
-        cachedData = json
-        onSuccess(json)
+    $http.get(urls.locations, params: params, cache: true)
 
   return props
 


### PR DESCRIPTION
@ezwelty This closes #8.

However, I wanted to get your input on something… by changing both API calls to include `lat,lng` center coordinates, this had the effect of really tightly clustering all the locations towards the center of the map. Does this seem bad to you?

*current master version*
<img width="431" alt="screenshot 2017-03-04 22 31 52" src="https://cloud.githubusercontent.com/assets/59429/23585137/984186d6-012a-11e7-9e01-4f498e4c98cf.png">

*this new branch*
<img width="402" alt="screenshot 2017-03-04 22 31 24" src="https://cloud.githubusercontent.com/assets/59429/23585139/a8822f28-012a-11e7-9f84-3c7e0a1223a0.png">

