### PR TITLE
Add location should use locale aware types

### DIFF
--- a/src/coffee/directives.coffee
+++ b/src/coffee/directives.coffee
@@ -302,10 +302,12 @@ directives.locationTypeSelect = (BASE_PATH, $timeout, $translate, edibleTypesSer
   link: ($scope, $element, $attrs) ->
     $scope.edible_types_data = edibleTypesService.data
     $scope.show_types = false
-    $scope.filters = {}
+    $scope.filters = { edible_types: null }
     $scope.filtered = false
     $scope.et_quantity = 0
-    $scope.filters.edible_types = null
+
+    $scope.typeFullName = (type) ->
+      type.fullName($translate.use())
 
     $scope.blurInput = ()->
       #wait for all other handlers to run first
@@ -316,6 +318,7 @@ directives.locationTypeSelect = (BASE_PATH, $timeout, $translate, edibleTypesSer
 
     $scope.checkInputTypedLength = ()->
       max_results = $scope.edible_types_data.edible_types.length
+
       if $scope.filters.edible_types.length < 2
         $scope.et_quantity = 0
         $scope.filtered = false

--- a/src/jade/templates/location_type_select.jade
+++ b/src/jade/templates/location_type_select.jade
@@ -17,7 +17,7 @@
         ng-repeat="type in edible_types_data.edible_types|filter:filters.edible_types|limitTo:et_quantity as filteredTypes",
         ng-click="updateSelectedEdibleType(type)"
       )
-        | {{type.name}}
+        | {{typeFullName(type)}}
 
 .detail-links-container(ng-show="location.type_ids.length")
   p
@@ -26,4 +26,4 @@
       ng-click="removeEdibleType(id)",
       href="#removeType"
     )
-      | {{edible_types_data.edible_types_by_id[id].name}}
+      | {{typeFullName(edible_types_data.edible_types_by_id[id])}}

--- a/src/jade/templates/location_type_select.jade
+++ b/src/jade/templates/location_type_select.jade
@@ -1,13 +1,29 @@
 .detail-input-container
   form(name="edibleTypesForm")
-    input(ng-model="filters.edible_types", translate-attr="{placeholder: 'glossary.type.other'}", ng-focus="show_types=true", ng-blur="blurInput()" ng-change="checkInputTypedLength()")
+    input(
+      ng-model="filters.edible_types",
+      translate-attr="{placeholder: 'glossary.type.other'}",
+      ng-focus="show_types=true",
+      ng-blur="blurInput()"
+      ng-change="checkInputTypedLength()"
+    )
+
     .reset(ng-show="filtered", ng-click="clearEdibleType()")
+
     ul(class="select-dropdown", ng-show="show_types")
       li(ng-show="!filtered", translate="glossary.search_by_typing")
-      li(ng-show="filtered", ng-repeat="type in edible_types_data.edible_types|filter:filters.edible_types|limitTo:et_quantity as filteredTypes", ng-click="updateSelectedEdibleType(type)")
+      li(
+        ng-show="filtered",
+        ng-repeat="type in edible_types_data.edible_types|filter:filters.edible_types|limitTo:et_quantity as filteredTypes",
+        ng-click="updateSelectedEdibleType(type)"
+      )
         | {{type.name}}
 
 .detail-links-container(ng-show="location.type_ids.length")
   p
-    a(ng-repeat="id in location.type_ids", ng-click="removeEdibleType(id)", href="#removeType")
+    a(
+      ng-repeat="id in location.type_ids",
+      ng-click="removeEdibleType(id)",
+      href="#removeType"
+    )
       | {{edible_types_data.edible_types_by_id[id].name}}


### PR DESCRIPTION
Closes #13 

Renders the correct translated string on the dropdown and on selection. Since we actually search all fields on the `type` object when filtering, it searches across all languages. In terms of not changing that code, this seems the most convenient, as everything just works out of the box. However, you could run into situations where the filters are returning results that don't seem like they should be correct, but because the filter you've typed matches in a different language, they'd show up. This seems pretty edge-cased though… it seems like in general users will know what they are searching for when they go to type, and will just select whatever makes sense to them in the moment. Any additional results would just be ignored noise? 

If I'm off-base with that, let me know!